### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-07-02
+
+### Added
+- **Firmware vendor transition detection**: detects when a BBL/BFL file spans multiple firmware vendors (e.g. Betaflight sessions recorded before a board was reflashed to EmuFlight), warns with per-vendor session ranges, and corrects per-session output filename prefixes accordingly (prevents duplicate/incorrect prefixes like `BTFL_BTFL_*` or `EMUF_BTFL_*`)
+- **QUIC_ fork exemption**: `FORK_REVISION_MAP` exempts known Betaflight forks (Quicksilver/`QUIC_`) from false-positive vendor-transition renames, since Quicksilver intentionally writes Betaflight revision headers for Blackbox Explorer compatibility
+- **`sanitize_base_name_override()`**: prevents path traversal via the public library API's base-name override
+- **`vendor_name_for_prefix()`**: single source of truth for prefix-to-display-name mapping
+
+### Fixed
+- **Universal gyro activity filtering** (#40): ground-test logs without duration metadata (common in INAV and older Betaflight) no longer produce "Data Unavailable" output. Replaced scale-dependent variance detection with scale-independent gyro range detection (`MIN_GYRO_RANGE = 500.0`), lowered the no-duration frame fallback threshold (`FALLBACK_MIN_FRAMES = 7,500`), and fixed NaN propagation in `calculate_range()` for conservative handling of bad data. `calculate_variance()` is retained but deprecated (`#[deprecated(since = "1.0.0")]`) in favor of `calculate_range()`.
+- **Release workflow**: corrected the binary version check that compared the full `bbl_parser 1.0.0 <sha> (<date>)` output against a string missing the `bbl_parser` prefix
+- **`time` crate RUSTSEC-2026-0009**: updated the transitive `time` dependency (via the `vergen`/`vergen-gitcl` build-dependency) to 0.3.53, patching a denial-of-service via stack exhaustion (CVSS 6.8, medium)
+
+### Changed
+- **Release artifact packaging**: CI and release workflows now build ZIP archives (`bbl_parser`/`bbl_parser.exe` inside) instead of uploading loose binaries, for cleaner, versioned release pages
+- **Dependency update**: broad `cargo update` sweep (clap 4.5.40 → 4.6.1, serde 1.0.140 → 1.0.150, regex 1.11.1 → 1.12.4, syn 2.0.103 → 2.0.118, libc 0.2.173 → 0.2.186, and others)
+- **Build tooling**: migrated `vergen` 8 → `vergen-gitcl` 10 (`EmitBuilder`/`git_sha`/`git_commit_date` → `Emitter`/`Gitcl::all_git()`); `VERGEN_GIT_SHA`/`VERGEN_GIT_COMMIT_DATE` env var names are unchanged, so no downstream code changes were required
+
 ## [1.0.0] - 2025-12-29
 
 ### Added
@@ -97,5 +115,6 @@ while providing the benefits of a modern, type-safe Rust library.
 
 ## Version History
 
+- **1.0.1** (2026-07-02) - Firmware vendor transition detection, universal gyro activity filtering fix, dependency updates
 - **1.0.0** (2025-12-29) - First stable release
 - **0.9.0** (2025-08+) - Development releases leading up to 1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "bbl_parser"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbl_parser"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["nerdCopter"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
AI Generated pull-request

## Summary

Version bump to 1.0.1, packaging all changes merged to master since the 1.0.0 release:

### Added
- Firmware vendor transition detection (warns and corrects output filename prefixes when a BBL/BFL file spans multiple firmware vendors, e.g. Betaflight sessions before a reflash to EmuFlight)
- QUIC_ (Quicksilver) fork exemption from false-positive vendor-transition renames
- `sanitize_base_name_override()` to prevent path traversal via the public library API
- `vendor_name_for_prefix()` as single source of truth for prefix-to-display-name mapping

### Fixed
- Universal gyro activity filtering (#40): ground-test logs without duration metadata no longer produce "Data Unavailable" output; switched to scale-independent gyro range detection (`MIN_GYRO_RANGE = 500.0`), lowered fallback frame threshold (`FALLBACK_MIN_FRAMES = 7,500`), fixed NaN propagation in `calculate_range()`
- Release workflow binary version check (was comparing against a string missing the `bbl_parser` prefix)
- `time` crate RUSTSEC-2026-0009 (DoS via stack exhaustion, CVSS 6.8) via update to 0.3.53

### Changed
- Release artifacts now packaged as ZIP archives instead of loose binaries
- Broad `cargo update` dependency sweep (clap, serde, regex, syn, libc, and others)
- Build tooling: `vergen` 8 → `vergen-gitcl` 10 (env var names unchanged, no downstream code changes)

Full details in [CHANGELOG.md](https://github.com/nerdCopter/bbl_parser/blob/release/v1.0.1/CHANGELOG.md#101---2026-07-02).

## Test plan
- [x] `cargo build --release` and `cargo test --release` pass (19 unit/integration tests + 3 doc-tests)
- [x] `bbl_parser --version` reports `1.0.1`