### PR TITLE
fix: append build info to release notes instead of replacing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BUILD_INFO="${{ steps.version.outputs.build_info }}"
+          EXISTING_NOTES=$(gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" --json body -q .body)
           gh release edit "${{ github.ref_name }}" \
-            --notes "**Build Information:** $BUILD_INFO" \
+            --notes "$(printf '%s\n\n---\n**Build Information:** %s' "$EXISTING_NOTES" "$BUILD_INFO")" \
             --repo "${{ github.repository }}"
           echo "🎉 Release $BUILD_INFO is now live with platform-specific ZIP files!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BUILD_INFO="${{ steps.version.outputs.build_info }}"
-          EXISTING_NOTES=$(gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" --json body -q .body)
+          EXISTING_NOTES=$(gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" --json body -q '.body // ""')
           gh release edit "${{ github.ref_name }}" \
             --notes "$(printf '%s\n\n---\n**Build Information:** %s' "$EXISTING_NOTES" "$BUILD_INFO")" \
             --repo "${{ github.repository }}"


### PR DESCRIPTION
AI Generated pull-request

## Summary
- The `upload-release-assets` job's "Update release notes" step ran `gh release edit --notes "**Build Information:** $BUILD_INFO"`, which replaces the entire release body — discarding whatever description was written when the release was created.
- Fetch the existing release body first and append the build-info footer to it instead of overwriting it.
- Found while preparing the v1.0.1 release: this bug never surfaced for v1.0.0 because that release's workflow run failed earlier (crates.io publish conflict + a version-check bug fixed later in #38/acad028), so the notes-overwrite step never ran.

## Test plan
- [x] `release.yml` YAML is well-formed (reviewed diff manually)
- [ ] Verify on the actual v1.0.1 release: after CI completes, confirm the release body still contains the full description with the build-info line appended