### PR TITLE
fix: restore short git SHA in version banner

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use vergen_gitcl::{Emitter, Gitcl};
 
 fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&Gitcl::all_git())?
+        .add_instructions(&Gitcl::all().sha(true).build())?
         .emit()?;
     Ok(())
 }


### PR DESCRIPTION
AI Generated pull-request

## Summary
- The `vergen` 8 -> `vergen-gitcl` 10 migration (#44) switched `build.rs` from `EmitBuilder::git_sha(true)` (short SHA) to `Gitcl::all_git()`, which emits the full 40-char `VERGEN_GIT_SHA` instead.
- Regression: `bbl_parser --version` now prints the full SHA (`bbl_parser 1.0.1 76b67b5d7a48cb79125ab18be6864c77f44bbb9d (2026-07-02)`) instead of the short one used since 1.0.0 (`bbl_parser 1.0.0 03b87d3 (2025-12-30)`).
- Fix: `Gitcl::all().sha(true).build()` keeps all other `VERGEN_GIT_*` instructions enabled while restoring short-SHA output (`Gitcl::builder().all()` is a private crate-internal method, so `Gitcl::all()` is the public equivalent).

## Test plan
- [x] `cargo build --release` and `cargo test --release` pass (19 unit/integration tests + 3 doc-tests)
- [x] `bbl_parser --version` now prints a 7-char short SHA (e.g. `61448ef`)