### PR TITLE
fix: move --repo/--clobber inside find -exec command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Find all ZIP files in artifacts
-          find release-artifacts -name "*.zip" -type f -exec gh release upload "${{ github.ref_name }}" {} \; --repo "${{ github.repository }}" --clobber
+          find release-artifacts -name "*.zip" -type f -exec gh release upload "${{ github.ref_name }}" {} --repo "${{ github.repository }}" --clobber \;
           echo "✅ All ZIP binaries uploaded"
 
       - name: Update release notes


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `find release-artifacts -name "*.zip" -type f -exec gh release upload "${{ github.ref_name }}" {} \; --repo "${{ github.repository }}" --clobber` terminates the `-exec` command at `\;` and passes `--repo`/`--clobber` as additional `find` predicates, which `find` rejects (`find: unknown predicate `--repo'`), failing the step with exit 1 before `gh` ever runs.
- Confirmed live: this broke the "Upload Assets to GitHub Release" job on the v1.0.1 release run (https://github.com/nerdCopter/bbl_parser/actions/runs/28620774194) — the ZIP binaries and the "Update release notes" step (gated on this step succeeding) never ran. Worked around manually for v1.0.1 by downloading the CI-built ZIPs and uploading/editing notes by hand.
- Fix: move `\;` to the end so `--repo` and `--clobber` are part of the exec'd `gh release upload` invocation, not `find` arguments.

## Test plan
- [ ] Verify on the next tagged release that "Upload Assets to GitHub Release" succeeds end-to-end without manual intervention